### PR TITLE
More complete XMLHttpRequest interface in Ajax

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,25 +2,94 @@
 
 ## Module Data.DOM.Simple.Ajax
 
+### Types
+
+    data ArrayBuffer :: *
+
+    data ArrayBufferView :: *
+
+    data Blob :: *
+
+    data FormData :: *
+
+    data HttpData a where
+      NoData :: HttpData a
+      TextData :: String -> HttpData a
+      ArrayBufferData :: ArrayBuffer -> HttpData a
+      ArrayBufferViewData :: ArrayBufferView -> HttpData a
+      BlobData :: Blob -> HttpData a
+      FormData :: FormData -> HttpData a
+      DocumentData :: HTMLDocument -> HttpData a
+      JsonData :: a -> HttpData a
+
+    data HttpMethod where
+      GET :: HttpMethod
+      POST :: HttpMethod
+      PUT :: HttpMethod
+      DELETE :: HttpMethod
+      PATCH :: HttpMethod
+      HEAD :: HttpMethod
+      OPTIONS :: HttpMethod
+      JSONP :: HttpMethod
+      HttpMethod :: String -> HttpMethod
+
+    data ReadyState where
+      Unsent :: ReadyState
+      Opened :: ReadyState
+      HeadersReceived :: ReadyState
+      Loading :: ReadyState
+      Done :: ReadyState
+
+    data ResponseType where
+      Default :: ResponseType
+      ArrayBuffer :: ResponseType
+      Blob :: ResponseType
+      Document :: ResponseType
+      Json :: ResponseType
+      Text :: ResponseType
+      MozBlob :: ResponseType
+      MozChunkedText :: ResponseType
+      MozChunkedArrayBuffer :: ResponseType
+
+    type Url  = String
+
+
+### Type Class Instances
+
+    instance showHttpMethod :: Show HttpMethod
+
+    instance showResponseType :: Show ResponseType
+
+
 ### Values
 
     getAllResponseHeaders :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
 
-    getResponseHeader :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) String
+    getResponseHeader :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) (Maybe String)
 
     makeXMLHttpRequest :: forall eff. Eff (dom :: DOM | eff) XMLHttpRequest
 
-    open :: forall eff. String -> String -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+    onReadyStateChange :: forall eff e. Eff e Unit -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
 
-    overrideMimeType :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) String
+    open :: forall eff. HttpMethod -> Url -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+
+    overrideMimeType :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+
+    readyState :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ReadyState
+
+    response :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) (HttpData a)
 
     responseText :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
 
-    send :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+    responseType :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ResponseType
 
-    sendWithPayload :: forall eff a. a -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+    send :: forall eff a. HttpData a -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
 
     setRequestHeader :: forall eff. String -> String -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+
+    setResponseType :: forall eff. ResponseType -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+
+    status :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
 
     statusText :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
 
@@ -264,6 +333,29 @@
     data Timeout :: *
 
     data XMLHttpRequest :: *
+
+
+## Module Data.DOM.Simple.Unsafe.Ajax
+
+### Values
+
+    unsafeGetResponseHeader :: forall eff a. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) String)
+
+    unsafeOnReadyStateChange :: forall eff e. Fn2 XMLHttpRequest (Eff e Unit) (Eff (dom :: DOM | eff) Unit)
+
+    unsafeOpen :: forall eff. Fn3 XMLHttpRequest String String (Eff (dom :: DOM | eff) Unit)
+
+    unsafeReadyState :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
+
+    unsafeResponse :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) a
+
+    unsafeResponseType :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+
+    unsafeSend :: forall eff. Fn1 XMLHttpRequest (Eff (dom :: DOM | eff) Unit)
+
+    unsafeSendWithPayload :: forall eff a. Fn2 XMLHttpRequest a (Eff (dom :: DOM | eff) Unit)
+
+    unsafeSetResponseType :: forall eff. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) Unit)
 
 
 ## Module Data.DOM.Simple.Unsafe.Document

--- a/src/Data/DOM/Simple/Ajax.purs
+++ b/src/Data/DOM/Simple/Ajax.purs
@@ -1,39 +1,155 @@
-module Data.DOM.Simple.Ajax where
+module Data.DOM.Simple.Ajax
+  ( ReadyState(..)
+  , Url(..)
+  , HttpMethod(..)
+  , ResponseType(..)
+  , ArrayBuffer(..)
+  , ArrayBufferView(..)
+  , Blob(..)
+  , FormData(..)
+  , HttpData(..)
+  , makeXMLHttpRequest
+  , readyState
+  , onReadyStateChange
+  , open
+  , send
+  , setResponseType
+  , responseType
+  , response
+  , responseText
+  , status
+  , statusText
+  , setRequestHeader
+  , getAllResponseHeaders
+  , getResponseHeader
+  , overrideMimeType
+  ) where
 
 import Control.Monad.Eff
+import Data.Function
+import Data.Maybe (Maybe(..))
+
 import Data.DOM.Simple.Types
+import Data.DOM.Simple.Unsafe.Ajax
+
+data ReadyState = Unsent | Opened | HeadersReceived | Loading | Done
+
+type Url = String
+
+data HttpMethod = GET | POST | PUT | DELETE | PATCH | HEAD | OPTIONS | JSONP | HttpMethod String
+
+data ResponseType = Default | ArrayBuffer | Blob | Document | Json | Text | MozBlob | MozChunkedText | MozChunkedArrayBuffer
+
+-- These could be given more complete interfaces somewhere:
+foreign import data ArrayBuffer :: *
+foreign import data ArrayBufferView :: *
+foreign import data Blob :: *
+foreign import data FormData :: *
+
+data HttpData a
+  = NoData
+  | TextData String
+  | ArrayBufferData ArrayBuffer
+  | ArrayBufferViewData ArrayBufferView
+  | BlobData Blob
+  | FormData FormData
+  | DocumentData HTMLDocument -- not necessarily HTML
+  | JsonData a
+
+instance showHttpMethod :: Show HttpMethod where
+  show GET = "GET"
+  show POST = "POST"
+  show PUT = "PUT"
+  show DELETE = "DELETE"
+  show PATCH = "PATCH"
+  show HEAD = "HEAD"
+  show OPTIONS = "OPTIONS"
+  show JSONP = "JSONP"
+  show (HttpMethod m) = m
+
+instance showResponseType :: Show ResponseType where
+  show Default = ""
+  show ArrayBuffer = "arraybuffer"
+  show Blob = "blob"
+  show Document = "document"
+  show Json = "json"
+  show Text = "text"
+  show MozBlob = "moz-blob"
+  show MozChunkedText = "moz-chunked-text"
+  show MozChunkedArrayBuffer = "moz-chunked-arraybuffer"
+
+foreign import maybeFn """
+  function maybeFn(nothing, just, a) {
+    return a == null ? nothing : just(a);
+  }""" :: forall a b. Fn3 b (a -> b) a b
+
+maybe :: forall a. a -> Maybe a
+maybe = runFn3 maybeFn Nothing Just
 
 foreign import makeXMLHttpRequest
   "function makeXMLHttpRequest() {  \
   \  return new XMLHttpRequest();   \
   \}" :: forall eff. (Eff (dom :: DOM | eff) XMLHttpRequest)
 
-foreign import open
-  "function open(method) {                \
-  \  return function(url) {               \
-  \    return function (obj) {            \
-  \      return function () {             \
-  \         obj.open(method, url);        \
-  \      };                               \
-  \    };                                 \
-  \  };                                   \
-  \}" :: forall eff. String -> String -> XMLHttpRequest -> (Eff (dom :: DOM | eff) Unit)
+readyState :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ReadyState
+readyState x = do
+  r <- unsafeReadyState x
+  return $ case r of
+    0 -> Unsent
+    1 -> Opened
+    2 -> HeadersReceived
+    3 -> Loading
+    4 -> Done
 
-foreign import send
-  "function send(obj) {     \
-  \  return function () {   \
-  \    obj.send();          \
-  \  };                     \
-  \}" :: forall eff. XMLHttpRequest -> (Eff (dom :: DOM | eff) Unit)
+onReadyStateChange :: forall eff e. Eff e Unit -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+onReadyStateChange f x = runFn2 unsafeOnReadyStateChange x f
 
-foreign import sendWithPayload
-  "function sendWithPayload(payload) {  \
-  \  return function (obj) {            \
-  \    return function () {             \
-  \      obj.send(payload);             \
-  \    };                               \
-  \  };                                 \
-  \}" :: forall eff a. a -> XMLHttpRequest -> (Eff (dom :: DOM | eff) Unit)
+open :: forall eff. HttpMethod -> Url -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+open m u x = runFn3 unsafeOpen x (show m) u
+
+send :: forall eff a. HttpData a -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+send NoData                  x = runFn1 unsafeSend x
+send (TextData a)            x = runFn2 unsafeSendWithPayload x a
+send (ArrayBufferData a)     x = runFn2 unsafeSendWithPayload x a
+send (ArrayBufferViewData a) x = runFn2 unsafeSendWithPayload x a
+send (BlobData a)            x = runFn2 unsafeSendWithPayload x a
+send (DocumentData a)        x = runFn2 unsafeSendWithPayload x a
+send (FormData a)            x = runFn2 unsafeSendWithPayload x a
+send (JsonData a)            x = runFn2 unsafeSendWithPayload x a -- XXX should be encoded
+
+setResponseType :: forall eff. ResponseType -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+setResponseType rt x = runFn2 unsafeSetResponseType x (show rt)
+
+responseType :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ResponseType
+responseType obj = do
+  r <- unsafeResponseType obj
+  return $ case r of
+    "" -> Default
+    "arraybuffer" -> ArrayBuffer
+    "blob" -> Blob
+    "document" -> Document
+    "json" -> Json
+    "text" -> Text
+    "moz-blob" -> MozBlob
+    "moz-chunked-test" -> MozChunkedText
+    "moz-chunked-arraybuffer" -> MozChunkedArrayBuffer
+
+response :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) (HttpData a)
+response x = do
+  t <- responseType x
+  case t of
+    Default               -> get TextData
+    ArrayBuffer           -> get ArrayBufferData
+    Blob                  -> get BlobData
+    Document              -> get DocumentData
+    Json                  -> get JsonData
+    Text                  -> get TextData
+    MozBlob               -> get BlobData
+    MozChunkedText        -> get TextData
+    MozChunkedArrayBuffer -> get ArrayBufferData
+  where
+    get :: forall eff a o. (a -> HttpData o) -> Eff (dom :: DOM | eff) (HttpData o)
+    get t = runFn3 maybeFn NoData t <$> unsafeResponse x
 
 foreign import responseText
   "function responseText(obj) {         \
@@ -41,6 +157,13 @@ foreign import responseText
   \      return obj.responseText;       \
   \  };                                 \
   \}" :: forall eff. XMLHttpRequest -> (Eff (dom :: DOM | eff) String)
+
+foreign import status """
+  function status(obj) {
+    return function () {
+      return obj.status;
+    };
+  }""" :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
 
 foreign import statusText
   "function statusText(obj) {         \
@@ -55,6 +178,7 @@ foreign import setRequestHeader
   \     return function (obj) {               \
   \       return function () {                \
   \         obj.setRequestHeader(key, value); \
+  \         return {};                        \
   \       }                                   \
   \     }                                     \
   \   }                                       \
@@ -67,20 +191,15 @@ foreign import getAllResponseHeaders
   \  };                                      \
   \}" :: forall eff. XMLHttpRequest -> (Eff (dom :: DOM | eff) String)
 
-foreign import getResponseHeader
-  "function getResponseHeader(key) {        \
-  \  return function (obj) {                \
-  \    return function () {                 \
-  \      return obj.getResponseHeader(key); \
-  \    };                                   \
-  \  };                                     \
-  \}" :: forall eff. String -> XMLHttpRequest -> (Eff (dom :: DOM | eff) String)
+getResponseHeader :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) (Maybe String)
+getResponseHeader k x = maybe <$> runFn2 unsafeGetResponseHeader x k
 
 foreign import overrideMimeType
   "function overrideMimeType(mime) {        \
   \  return function (obj) {                \
   \    return function () {                 \
-  \      return obj.overrideMimeType(mine); \
+  \      obj.overrideMimeType(mine); \
+  \      return {}; \
   \    };                                   \
   \  };                                     \
-  \}" :: forall eff. String -> XMLHttpRequest -> (Eff (dom :: DOM | eff) String)
+  \}" :: forall eff. String -> XMLHttpRequest -> (Eff (dom :: DOM | eff) Unit)

--- a/src/Data/DOM/Simple/Unsafe/Ajax.purs
+++ b/src/Data/DOM/Simple/Unsafe/Ajax.purs
@@ -1,0 +1,75 @@
+module Data.DOM.Simple.Unsafe.Ajax where
+
+import Control.Monad.Eff
+import Data.Function
+
+import Data.DOM.Simple.Types
+
+foreign import unsafeReadyState """
+  function unsafeReadyState(obj) {
+    return function () {
+      return obj.readyState;
+    };
+  }""" :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
+
+foreign import unsafeOnReadyStateChange """
+  function unsafeOnReadyStateChange(obj, fn) {
+    return function () {
+      obj.onreadystatechange = fn;
+      return {};
+    };
+  }""" :: forall eff e. Fn2 XMLHttpRequest (Eff e Unit) (Eff (dom :: DOM | eff) Unit)
+
+foreign import unsafeOpen """
+  function unsafeOpen(obj, method, url) {
+    return function () {
+      obj.open(method, url);
+      return {};
+    };
+  }""" :: forall eff. Fn3 XMLHttpRequest String String (Eff (dom :: DOM | eff) Unit)
+
+foreign import unsafeSend """
+  function unsafeSend(obj) {
+    return function () {
+      obj.send();
+      return {};
+    };
+  }""" :: forall eff. Fn1 XMLHttpRequest (Eff (dom :: DOM | eff) Unit)
+
+foreign import unsafeSendWithPayload """
+  function unsafeSendWithPayload(obj, payload) {
+    return function () {
+      obj.send(payload);
+      return {};
+    };
+  }""" :: forall eff a. Fn2 XMLHttpRequest a (Eff (dom :: DOM | eff) Unit)
+
+foreign import unsafeSetResponseType """
+  function unsafeSetResponseType(obj, rt) {
+    return function () {
+      obj.responseType = rt;
+      return {};
+    };
+  }""" :: forall eff. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) Unit)
+
+foreign import unsafeResponseType """
+  function unsafeResponseType(obj) {
+    return function () {
+      return obj.responseType;
+    };
+  }""" :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+
+foreign import unsafeResponse """
+  function unsafeResponse(obj) {
+    return function () {
+      return obj.response;
+    };
+  }""" :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) a
+
+foreign import unsafeGetResponseHeader """
+  function unsafeGetResponseHeader(obj, key) {
+    return function () {
+      return obj.getResponseHeader(key);
+    };
+  }""" :: forall eff a. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) String)
+


### PR DESCRIPTION
Includes content (request and response) abstraction and basic event handling.  I've moved the support functions into Unsafe like the other modules (though not all of them are necessarily unsafe).  There are still a few things missing, but there's enough to make it usable.  I'd add tests, but node doesn't support `XMLHttpRequest`.  It'd be nice to have better interfaces for things like `ArrayBuffer`, too, but this doesn't seem like the right place.  Some of this is based on https://github.com/purescript-contrib/purescript-angular/blob/master/src/Angular/Http/Types.purs which will be changed to use this package.
