### PR TITLE
Use "location.assign" instead of "location ="

### DIFF
--- a/src/Data/DOM/Simple/Unsafe/Window.purs
+++ b/src/Data/DOM/Simple/Unsafe/Window.purs
@@ -30,7 +30,7 @@ foreign import unsafeSetLocation
   "function unsafeSetLocation(value) {  \
   \  return function (loc) {            \
   \    return function () {             \
-  \      location = value;              \
+  \      location.assign(value);        \
   \    };                               \
   \  };                                 \
   \}" :: forall eff a. String -> a -> (Eff (dom :: DOM | eff) Unit)


### PR DESCRIPTION
As it currently stands, the stable release of closure-compiler errors out due
to the use of "location = value;".

See: 
https://groups.google.com/forum/#!topic/closure-compiler-discuss/sbAQr18Xe9g

According to https://developer.mozilla.org/en-US/docs/Web/API/window.location,
`window.location` is technically read-only but lets you assign to it using `=`
anyway, to change the URL.

Because of that, this is definitely a closure-compiler issue (and was fixed in
git), but it seems like a simple enough change that can be made in
purescript-simple-dom so that the stable closure-compiler can work with it
too.

There is no functionality change at all, this simply uses `.assign()` instead
of `=` and according to the specification, they do the same thing.

Signed-off-by: Ricky Elrod ricky@elrod.me
