### PR TITLE
Use purescript-dom from contrib

### DIFF
--- a/API.md
+++ b/API.md
@@ -51,7 +51,7 @@
       MozChunkedText :: ResponseType
       MozChunkedArrayBuffer :: ResponseType
 
-    type Url  = String
+    type Url = String
 
 
 ### Type Class Instances
@@ -336,8 +336,6 @@
 ## Module Data.DOM.Simple.Types
 
 ### Types
-
-    data DOM :: !
 
     data DOMEvent :: *
 

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
   ],
   "main": [],
   "dependencies": {
+    "purescript-dom": "*",
     "purescript-arrays": "*",
     "purescript-maybe": "*",
     "purescript-foldable-traversable": "*",

--- a/src/Data/DOM/Simple/Ajax.purs
+++ b/src/Data/DOM/Simple/Ajax.purs
@@ -28,6 +28,7 @@ module Data.DOM.Simple.Ajax
 import Control.Monad.Eff
 import Data.Function
 import Data.Maybe (Maybe(..))
+import DOM
 
 import Data.DOM.Simple.Types
 import Data.DOM.Simple.Unsafe.Ajax

--- a/src/Data/DOM/Simple/Document.purs
+++ b/src/Data/DOM/Simple/Document.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Document where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Types

--- a/src/Data/DOM/Simple/Element.purs
+++ b/src/Data/DOM/Simple/Element.purs
@@ -1,6 +1,7 @@
 module Data.DOM.Simple.Element where
 
 import Control.Monad.Eff
+import DOM
 
 import Data.DOM.Simple.Unsafe.Utils(ensure, showImpl)
 import Data.DOM.Simple.Unsafe.Element

--- a/src/Data/DOM/Simple/Encode.purs
+++ b/src/Data/DOM/Simple/Encode.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Encode where
 
+import DOM
 import Control.Monad.Eff
 import Data.DOM.Simple.Types
 

--- a/src/Data/DOM/Simple/Events.purs
+++ b/src/Data/DOM/Simple/Events.purs
@@ -7,6 +7,7 @@ import Data.DOM.Simple.Types
 import Data.DOM.Simple.Window(document, globalWindow)
 import Data.DOM.Simple.Ajax
 import Data.DOM.Simple.Unsafe.Events
+import DOM
 
 -- XXX Should this be in the Prelude?
 class Read s where

--- a/src/Data/DOM/Simple/Navigator.purs
+++ b/src/Data/DOM/Simple/Navigator.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Navigator where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Unsafe.Navigator

--- a/src/Data/DOM/Simple/Sugar.purs
+++ b/src/Data/DOM/Simple/Sugar.purs
@@ -21,6 +21,7 @@ import Data.DOM.Simple.Types
 import Data.DOM.Simple.Element
 import Data.DOM.Simple.Document
 import Data.DOM.Simple.Unsafe.Sugar
+import DOM
 
 class DOMArrows b where
   (#<-) :: forall eff. b -> (Tuple String String) -> (Eff (dom :: DOM | eff) Unit)

--- a/src/Data/DOM/Simple/Types.purs
+++ b/src/Data/DOM/Simple/Types.purs
@@ -2,8 +2,6 @@ module Data.DOM.Simple.Types where
 
 import Control.Monad.Eff
 
-foreign import data DOM               :: !
-
 foreign import data HTMLElement       :: *
 foreign import data HTMLDocument      :: *
 foreign import data HTMLWindow        :: *

--- a/src/Data/DOM/Simple/Unsafe/Ajax.purs
+++ b/src/Data/DOM/Simple/Unsafe/Ajax.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Unsafe.Ajax where
 
+import DOM
 import Control.Monad.Eff
 import Data.Function
 

--- a/src/Data/DOM/Simple/Unsafe/Document.purs
+++ b/src/Data/DOM/Simple/Unsafe/Document.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Unsafe.Document where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Types

--- a/src/Data/DOM/Simple/Unsafe/Element.purs
+++ b/src/Data/DOM/Simple/Unsafe/Element.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Unsafe.Element where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Types

--- a/src/Data/DOM/Simple/Unsafe/Events.purs
+++ b/src/Data/DOM/Simple/Unsafe/Events.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Unsafe.Events where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Types

--- a/src/Data/DOM/Simple/Unsafe/Navigator.purs
+++ b/src/Data/DOM/Simple/Unsafe/Navigator.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Unsafe.Navigator where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Types

--- a/src/Data/DOM/Simple/Unsafe/Sugar.purs
+++ b/src/Data/DOM/Simple/Unsafe/Sugar.purs
@@ -1,6 +1,7 @@
 module Data.DOM.Simple.Unsafe.Sugar where
 
 import Control.Monad.Eff
+import DOM
 
 import Data.DOM.Simple.Element
 import Data.DOM.Simple.Types

--- a/src/Data/DOM/Simple/Unsafe/Window.purs
+++ b/src/Data/DOM/Simple/Unsafe/Window.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Unsafe.Window where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Types

--- a/src/Data/DOM/Simple/Window.purs
+++ b/src/Data/DOM/Simple/Window.purs
@@ -1,5 +1,6 @@
 module Data.DOM.Simple.Window where
 
+import DOM
 import Control.Monad.Eff
 
 import Data.DOM.Simple.Types


### PR DESCRIPTION
purescript-dom only exports DOM types which are equivalent to those in
this library. Since its available from purescript-contrib, its pretty
widely used so this should use that version.

Without this change, mixing effectful code that uses
purescript-contrib's DOM and code from this library won't compile
because there will be a duplicate row in the effect monad.

It should be noted that this would be a much cleaner fix if we had module reexports, but they are not yet available.