### PR TITLE
Add getter and setter for HTML element style attributes

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,599 +2,1379 @@
 
 ## Module Data.DOM.Simple.Ajax
 
-### Types
+#### `ReadyState`
 
-    data ArrayBuffer :: *
-
-    data ArrayBufferView :: *
-
-    data Blob :: *
-
-    data FormData :: *
-
-    data HttpData a where
-      NoData :: HttpData a
-      TextData :: String -> HttpData a
-      ArrayBufferData :: ArrayBuffer -> HttpData a
-      ArrayBufferViewData :: ArrayBufferView -> HttpData a
-      BlobData :: Blob -> HttpData a
-      FormData :: FormData -> HttpData a
-      DocumentData :: HTMLDocument -> HttpData a
-      JsonData :: a -> HttpData a
-
-    data HttpMethod where
-      GET :: HttpMethod
-      POST :: HttpMethod
-      PUT :: HttpMethod
-      DELETE :: HttpMethod
-      PATCH :: HttpMethod
-      HEAD :: HttpMethod
-      OPTIONS :: HttpMethod
-      JSONP :: HttpMethod
-      HttpMethod :: String -> HttpMethod
-
-    data ReadyState where
-      Unsent :: ReadyState
-      Opened :: ReadyState
-      HeadersReceived :: ReadyState
-      Loading :: ReadyState
-      Done :: ReadyState
-
-    data ResponseType where
-      Default :: ResponseType
-      ArrayBuffer :: ResponseType
-      Blob :: ResponseType
-      Document :: ResponseType
-      Json :: ResponseType
-      Text :: ResponseType
-      MozBlob :: ResponseType
-      MozChunkedText :: ResponseType
-      MozChunkedArrayBuffer :: ResponseType
-
-    type Url = String
+``` purescript
+data ReadyState
+  = Unsent 
+  | Opened 
+  | HeadersReceived 
+  | Loading 
+  | Done 
+```
 
 
-### Type Class Instances
+#### `Url`
 
-    instance showHttpMethod :: Show HttpMethod
+``` purescript
+type Url = String
+```
 
-    instance showResponseType :: Show ResponseType
+
+#### `HttpMethod`
+
+``` purescript
+data HttpMethod
+  = GET 
+  | POST 
+  | PUT 
+  | DELETE 
+  | PATCH 
+  | HEAD 
+  | OPTIONS 
+  | JSONP 
+  | HttpMethod String
+```
 
 
-### Values
+#### `ResponseType`
 
-    getAllResponseHeaders :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+``` purescript
+data ResponseType
+  = Default 
+  | ArrayBuffer 
+  | Blob 
+  | Document 
+  | Json 
+  | Text 
+  | MozBlob 
+  | MozChunkedText 
+  | MozChunkedArrayBuffer 
+```
 
-    getResponseHeader :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) (Maybe String)
 
-    makeXMLHttpRequest :: forall eff. Eff (dom :: DOM | eff) XMLHttpRequest
+#### `ArrayBuffer`
 
-    onReadyStateChange :: forall eff e. Eff e Unit -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+``` purescript
+data ArrayBuffer :: *
+```
 
-    open :: forall eff. HttpMethod -> Url -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+#### `ArrayBufferView`
 
-    overrideMimeType :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+``` purescript
+data ArrayBufferView :: *
+```
 
-    readyState :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ReadyState
 
-    response :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) (HttpData a)
+#### `Blob`
 
-    responseText :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+``` purescript
+data Blob :: *
+```
 
-    responseType :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ResponseType
 
-    send :: forall eff a. HttpData a -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+#### `FormData`
 
-    setRequestHeader :: forall eff. String -> String -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+``` purescript
+data FormData :: *
+```
 
-    setResponseType :: forall eff. ResponseType -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
 
-    status :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
+#### `HttpData`
 
-    statusText :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+``` purescript
+data HttpData a
+  = NoData 
+  | TextData String
+  | ArrayBufferData ArrayBuffer
+  | ArrayBufferViewData ArrayBufferView
+  | BlobData Blob
+  | FormData FormData
+  | DocumentData HTMLDocument
+  | JsonData a
+```
+
+
+#### `showHttpMethod`
+
+``` purescript
+instance showHttpMethod :: Show HttpMethod
+```
+
+
+#### `showResponseType`
+
+``` purescript
+instance showResponseType :: Show ResponseType
+```
+
+
+#### `makeXMLHttpRequest`
+
+``` purescript
+makeXMLHttpRequest :: forall eff. Eff (dom :: DOM | eff) XMLHttpRequest
+```
+
+
+#### `readyState`
+
+``` purescript
+readyState :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ReadyState
+```
+
+
+#### `onReadyStateChange`
+
+``` purescript
+onReadyStateChange :: forall eff e. Eff e Unit -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `open`
+
+``` purescript
+open :: forall eff. HttpMethod -> Url -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `send`
+
+``` purescript
+send :: forall eff a. HttpData a -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `setResponseType`
+
+``` purescript
+setResponseType :: forall eff. ResponseType -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+```
+
+#### `responseType`
+
+``` purescript
+responseType :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) ResponseType
+```
+
+
+#### `response`
+
+``` purescript
+response :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) (HttpData a)
+```
+
+
+#### `responseText`
+
+``` purescript
+responseText :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `status`
+
+``` purescript
+status :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
+```
+
+
+#### `statusText`
+
+``` purescript
+statusText :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `setRequestHeader`
+
+``` purescript
+setRequestHeader :: forall eff. String -> String -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `getAllResponseHeaders`
+
+``` purescript
+getAllResponseHeaders :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `getResponseHeader`
+
+``` purescript
+getResponseHeader :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) (Maybe String)
+```
+
+
+#### `overrideMimeType`
+
+``` purescript
+overrideMimeType :: forall eff. String -> XMLHttpRequest -> Eff (dom :: DOM | eff) Unit
+```
+
 
 
 ## Module Data.DOM.Simple.Document
 
-### Type Classes
+#### `Document`
 
-    class Document b where
-      title :: forall eff. b -> Eff (dom :: DOM | eff) String
-      setTitle :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      body :: forall eff. b -> Eff (dom :: DOM | eff) HTMLElement
-      setBody :: forall eff. HTMLElement -> b -> Eff (dom :: DOM | eff) Unit
+``` purescript
+class Document b where
+  title :: forall eff. b -> Eff (dom :: DOM | eff) String
+  setTitle :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  body :: forall eff. b -> Eff (dom :: DOM | eff) HTMLElement
+  setBody :: forall eff. HTMLElement -> b -> Eff (dom :: DOM | eff) Unit
+```
 
 
-### Type Class Instances
+#### `htmlDocumentElement`
 
-    instance htmlDocument :: Document HTMLDocument
+``` purescript
+instance htmlDocumentElement :: Element HTMLDocument
+```
 
-    instance htmlDocumentElement :: Element HTMLDocument
 
-    instance showHtmlDocument :: Show HTMLDocument
+#### `htmlDocument`
+
+``` purescript
+instance htmlDocument :: Document HTMLDocument
+```
+
+
+#### `showHtmlDocument`
+
+``` purescript
+instance showHtmlDocument :: Show HTMLDocument
+```
+
 
 
 ## Module Data.DOM.Simple.Element
 
-### Type Classes
+#### `Element`
 
-    class Element b where
-      getElementById :: forall eff. String -> b -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
-      getElementsByClassName :: forall eff. String -> b -> Eff (dom :: DOM | eff) [HTMLElement]
-      getElementsByName :: forall eff. String -> b -> Eff (dom :: DOM | eff) [HTMLElement]
-      querySelector :: forall eff. String -> b -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
-      querySelectorAll :: forall eff. String -> b -> Eff (dom :: DOM | eff) NodeList
-      getAttribute :: forall eff. String -> b -> Eff (dom :: DOM | eff) String
-      setAttribute :: forall eff. String -> String -> b -> Eff (dom :: DOM | eff) Unit
-      hasAttribute :: forall eff. String -> b -> Eff (dom :: DOM | eff) Boolean
-      removeAttribute :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      children :: forall eff. b -> Eff (dom :: DOM | eff) [HTMLElement]
-      innerHTML :: forall eff. b -> Eff (dom :: DOM | eff) String
-      setInnerHTML :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      textContent :: forall eff. b -> Eff (dom :: DOM | eff) String
-      setTextContent :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      value :: forall eff. b -> Eff (dom :: DOM | eff) String
-      setValue :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      contentWindow :: forall eff. b -> Eff (dom :: DOM | eff) HTMLWindow
-      classRemove :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      classAdd :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      classToggle :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      classContains :: forall eff. String -> b -> Eff (dom :: DOM | eff) Boolean
-
-
-### Type Class Instances
-
-    instance htmlElement :: Element HTMLElement
-
-    instance showHtmlElement :: Show HTMLElement
+``` purescript
+class Element b where
+  getElementById :: forall eff. String -> b -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+  getElementsByClassName :: forall eff. String -> b -> Eff (dom :: DOM | eff) [HTMLElement]
+  getElementsByName :: forall eff. String -> b -> Eff (dom :: DOM | eff) [HTMLElement]
+  querySelector :: forall eff. String -> b -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+  querySelectorAll :: forall eff. String -> b -> Eff (dom :: DOM | eff) NodeList
+  getAttribute :: forall eff. String -> b -> Eff (dom :: DOM | eff) String
+  setAttribute :: forall eff. String -> String -> b -> Eff (dom :: DOM | eff) Unit
+  hasAttribute :: forall eff. String -> b -> Eff (dom :: DOM | eff) Boolean
+  removeAttribute :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  getStyleAttr :: forall eff. String -> b -> Eff (dom :: DOM | eff) String
+  setStyleAttr :: forall eff. String -> String -> b -> Eff (dom :: DOM | eff) Unit
+  children :: forall eff. b -> Eff (dom :: DOM | eff) [HTMLElement]
+  innerHTML :: forall eff. b -> Eff (dom :: DOM | eff) String
+  setInnerHTML :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  textContent :: forall eff. b -> Eff (dom :: DOM | eff) String
+  setTextContent :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  value :: forall eff. b -> Eff (dom :: DOM | eff) String
+  setValue :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  contentWindow :: forall eff. b -> Eff (dom :: DOM | eff) HTMLWindow
+  classRemove :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  classAdd :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  classToggle :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  classContains :: forall eff. String -> b -> Eff (dom :: DOM | eff) Boolean
+```
 
 
-### Values
+#### `htmlElement`
 
-    blur :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+``` purescript
+instance htmlElement :: Element HTMLElement
+```
 
-    click :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
 
-    focus :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+#### `showHtmlElement`
 
-    setAttributes :: forall eff a. (Element a) => [T.Tuple String String] -> a -> Eff (dom :: DOM | eff) Unit
+``` purescript
+instance showHtmlElement :: Show HTMLElement
+```
+
+
+#### `setAttributes`
+
+``` purescript
+setAttributes :: forall eff a. (Element a) => [T.Tuple String String] -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `setStyleAttrs`
+
+``` purescript
+setStyleAttrs :: forall eff a. (Element a) => [T.Tuple String String] -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `click`
+
+``` purescript
+click :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `focus`
+
+``` purescript
+focus :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `blur`
+
+``` purescript
+blur :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+```
+
 
 
 ## Module Data.DOM.Simple.Encode
 
-### Values
+#### `encodeURIComponent`
 
-    decodeURI :: String -> String
+``` purescript
+encodeURIComponent :: String -> String
+```
 
-    decodeURIComponent :: String -> String
 
-    encodeURI :: String -> String
+#### `decodeURIComponent`
 
-    encodeURIComponent :: String -> String
+``` purescript
+decodeURIComponent :: String -> String
+```
 
-    paramatize :: forall a. a -> String
 
-    toJsonString :: forall eff a. a -> Eff (dom :: DOM | eff) String
+#### `encodeURI`
+
+``` purescript
+encodeURI :: String -> String
+```
+
+
+#### `decodeURI`
+
+``` purescript
+decodeURI :: String -> String
+```
+
+
+#### `paramatize`
+
+``` purescript
+paramatize :: forall a. a -> String
+```
+
+Given an object, convert it into URL parameters.
+
+#### `toJsonString`
+
+``` purescript
+toJsonString :: forall eff a. a -> Eff (dom :: DOM | eff) String
+```
+
+Given an object, convert it into a JSON string
 
 
 ## Module Data.DOM.Simple.Events
 
-### Types
+#### `Read`
 
-    data KeyLocation where
-      KeyLocationStandard :: KeyLocation
-      KeyLocationLeft :: KeyLocation
-      KeyLocationRight :: KeyLocation
-      KeyLocationNumpad :: KeyLocation
+``` purescript
+class Read s where
+  read :: String -> s
+```
 
-    data KeyboardEventType where
-      KeydownEvent :: KeyboardEventType
-      KeypressEvent :: KeyboardEventType
-      KeyupEvent :: KeyboardEventType
+#### `Event`
 
-    data MouseEventType where
-      MouseMoveEvent :: MouseEventType
-      MouseOverEvent :: MouseEventType
-      MouseEnterEvent :: MouseEventType
-      MouseOutEvent :: MouseEventType
-      MouseLeaveEvent :: MouseEventType
+``` purescript
+class Event e where
+  eventTarget :: forall eff a. e -> Eff (dom :: DOM | eff) a
+  stopPropagation :: forall eff. e -> Eff (dom :: DOM | eff) Unit
+  preventDefault :: forall eff. e -> Eff (dom :: DOM | eff) Unit
+```
 
-    data UIEventType where
-      LoadEvent :: UIEventType
-      UnloadEvent :: UIEventType
-      AbortEvent :: UIEventType
-      ErrorEvent :: UIEventType
-      SelectEvent :: UIEventType
-      ResizeEvent :: UIEventType
-      ScrollEvent :: UIEventType
+#### `eventDOMEvent`
+
+``` purescript
+instance eventDOMEvent :: Event DOMEvent
+```
 
 
-### Type Classes
+#### `MouseEventType`
 
-    class Event e where
-      eventTarget :: forall eff a. e -> Eff (dom :: DOM | eff) a
-      stopPropagation :: forall eff. e -> Eff (dom :: DOM | eff) Unit
-      preventDefault :: forall eff. e -> Eff (dom :: DOM | eff) Unit
+``` purescript
+data MouseEventType
+  = MouseMoveEvent 
+  | MouseOverEvent 
+  | MouseEnterEvent 
+  | MouseOutEvent 
+  | MouseLeaveEvent 
+```
 
-    class (Event e) <= KeyboardEvent e where
-      keyboardEventType :: forall eff. e -> Eff (dom :: DOM | eff) KeyboardEventType
-      key :: forall eff. e -> Eff (dom :: DOM | eff) String
-      keyCode :: forall eff. e -> Eff (dom :: DOM | eff) Number
-      keyLocation :: forall eff. e -> Eff (dom :: DOM | eff) KeyLocation
-      altKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
-      ctrlKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
-      metaKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
-      shiftKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
+#### `mouseEventTypeShow`
 
-    class KeyboardEventTarget b where
-      addKeyboardEventListener :: forall e t ta. (KeyboardEvent e) => KeyboardEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
-      removeKeyboardEventListener :: forall e t ta. (KeyboardEvent e) => KeyboardEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
-
-    class (Event e) <= MouseEvent e where
-      mouseEventType :: forall eff. e -> Eff (dom :: DOM | eff) MouseEventType
-      screenX :: forall eff. e -> Eff (dom :: DOM | eff) Number
-      screenY :: forall eff. e -> Eff (dom :: DOM | eff) Number
-
-    class MouseEventTarget b where
-      addMouseEventListener :: forall e t ta. (MouseEvent e) => MouseEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
-      removeMouseEventListener :: forall e t ta. (MouseEvent e) => MouseEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
-
-    class Read s where
-      read :: String -> s
-
-    class (Event e) <= UIEvent e where
-      view :: forall eff. e -> Eff (dom :: DOM | eff) HTMLWindow
-      detail :: forall eff. e -> Eff (dom :: DOM | eff) Number
-
-    class UIEventTarget b where
-      addUIEventListener :: forall e t ta. (UIEvent e) => UIEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
-      removeUIEventListener :: forall e t ta. (UIEvent e) => UIEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
+``` purescript
+instance mouseEventTypeShow :: Show MouseEventType
+```
 
 
-### Type Class Instances
+#### `mouseEventTypeRead`
 
-    instance eventDOMEvent :: Event DOMEvent
-
-    instance keyboardEventDOMEvent :: KeyboardEvent DOMEvent
-
-    instance keyboardEventTargetHTMLDocument :: KeyboardEventTarget HTMLDocument
-
-    instance keyboardEventTargetHTMLElement :: KeyboardEventTarget HTMLElement
-
-    instance keyboardEventTargetHTMLWindow :: KeyboardEventTarget HTMLWindow
-
-    instance keyboardEventTypeRead :: Read KeyboardEventType
-
-    instance keyboardEventTypeShow :: Show KeyboardEventType
-
-    instance mouseEventDOMEvent :: MouseEvent DOMEvent
-
-    instance mouseEventTargetHTMLDocument :: MouseEventTarget HTMLDocument
-
-    instance mouseEventTargetHTMLElement :: MouseEventTarget HTMLElement
-
-    instance mouseEventTargetHTMLWindow :: MouseEventTarget HTMLWindow
-
-    instance mouseEventTypeRead :: Read MouseEventType
-
-    instance mouseEventTypeShow :: Show MouseEventType
-
-    instance uiEventDOMEvent :: UIEvent DOMEvent
-
-    instance uiEventTargetHTMLWindow :: UIEventTarget HTMLWindow
-
-    instance uiEventTypeRead :: Read UIEventType
-
-    instance uiEventTypeShow :: Show UIEventType
+``` purescript
+instance mouseEventTypeRead :: Read MouseEventType
+```
 
 
-### Values
+#### `MouseEvent`
 
-    toKeyLocation :: Number -> KeyLocation
+``` purescript
+class (Event e) <= MouseEvent e where
+  mouseEventType :: forall eff. e -> Eff (dom :: DOM | eff) MouseEventType
+  screenX :: forall eff. e -> Eff (dom :: DOM | eff) Number
+  screenY :: forall eff. e -> Eff (dom :: DOM | eff) Number
+```
+
+
+#### `mouseEventDOMEvent`
+
+``` purescript
+instance mouseEventDOMEvent :: MouseEvent DOMEvent
+```
+
+
+#### `MouseEventTarget`
+
+``` purescript
+class MouseEventTarget b where
+  addMouseEventListener :: forall e t ta. (MouseEvent e) => MouseEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
+  removeMouseEventListener :: forall e t ta. (MouseEvent e) => MouseEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
+```
+
+
+#### `mouseEventTargetHTMLWindow`
+
+``` purescript
+instance mouseEventTargetHTMLWindow :: MouseEventTarget HTMLWindow
+```
+
+
+#### `mouseEventTargetHTMLDocument`
+
+``` purescript
+instance mouseEventTargetHTMLDocument :: MouseEventTarget HTMLDocument
+```
+
+
+#### `mouseEventTargetHTMLElement`
+
+``` purescript
+instance mouseEventTargetHTMLElement :: MouseEventTarget HTMLElement
+```
+
+
+#### `KeyboardEventType`
+
+``` purescript
+data KeyboardEventType
+  = KeydownEvent 
+  | KeypressEvent 
+  | KeyupEvent 
+```
+
+#### `keyboardEventTypeShow`
+
+``` purescript
+instance keyboardEventTypeShow :: Show KeyboardEventType
+```
+
+
+#### `keyboardEventTypeRead`
+
+``` purescript
+instance keyboardEventTypeRead :: Read KeyboardEventType
+```
+
+
+#### `KeyLocation`
+
+``` purescript
+data KeyLocation
+  = KeyLocationStandard 
+  | KeyLocationLeft 
+  | KeyLocationRight 
+  | KeyLocationNumpad 
+```
+
+
+#### `toKeyLocation`
+
+``` purescript
+toKeyLocation :: Number -> KeyLocation
+```
+
+
+#### `KeyboardEvent`
+
+``` purescript
+class (Event e) <= KeyboardEvent e where
+  keyboardEventType :: forall eff. e -> Eff (dom :: DOM | eff) KeyboardEventType
+  key :: forall eff. e -> Eff (dom :: DOM | eff) String
+  keyCode :: forall eff. e -> Eff (dom :: DOM | eff) Number
+  keyLocation :: forall eff. e -> Eff (dom :: DOM | eff) KeyLocation
+  altKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
+  ctrlKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
+  metaKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
+  shiftKey :: forall eff. e -> Eff (dom :: DOM | eff) Boolean
+```
+
+
+#### `keyboardEventDOMEvent`
+
+``` purescript
+instance keyboardEventDOMEvent :: KeyboardEvent DOMEvent
+```
+
+
+#### `KeyboardEventTarget`
+
+``` purescript
+class KeyboardEventTarget b where
+  addKeyboardEventListener :: forall e t ta. (KeyboardEvent e) => KeyboardEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
+  removeKeyboardEventListener :: forall e t ta. (KeyboardEvent e) => KeyboardEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
+```
+
+
+#### `keyboardEventTargetHTMLWindow`
+
+``` purescript
+instance keyboardEventTargetHTMLWindow :: KeyboardEventTarget HTMLWindow
+```
+
+
+#### `keyboardEventTargetHTMLDocument`
+
+``` purescript
+instance keyboardEventTargetHTMLDocument :: KeyboardEventTarget HTMLDocument
+```
+
+
+#### `keyboardEventTargetHTMLElement`
+
+``` purescript
+instance keyboardEventTargetHTMLElement :: KeyboardEventTarget HTMLElement
+```
+
+
+#### `UIEventType`
+
+``` purescript
+data UIEventType
+  = LoadEvent 
+  | UnloadEvent 
+  | AbortEvent 
+  | ErrorEvent 
+  | SelectEvent 
+  | ResizeEvent 
+  | ScrollEvent 
+```
+
+#### `uiEventTypeShow`
+
+``` purescript
+instance uiEventTypeShow :: Show UIEventType
+```
+
+
+#### `uiEventTypeRead`
+
+``` purescript
+instance uiEventTypeRead :: Read UIEventType
+```
+
+
+#### `UIEvent`
+
+``` purescript
+class (Event e) <= UIEvent e where
+  view :: forall eff. e -> Eff (dom :: DOM | eff) HTMLWindow
+  detail :: forall eff. e -> Eff (dom :: DOM | eff) Number
+```
+
+
+#### `uiEventDOMEvent`
+
+``` purescript
+instance uiEventDOMEvent :: UIEvent DOMEvent
+```
+
+
+#### `UIEventTarget`
+
+``` purescript
+class UIEventTarget b where
+  addUIEventListener :: forall e t ta. (UIEvent e) => UIEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
+  removeUIEventListener :: forall e t ta. (UIEvent e) => UIEventType -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | ta) Unit
+```
+
+
+#### `uiEventTargetHTMLWindow`
+
+``` purescript
+instance uiEventTargetHTMLWindow :: UIEventTarget HTMLWindow
+```
+
 
 
 ## Module Data.DOM.Simple.Navigator
 
-### Type Classes
+#### `Navigator`
 
-    class Navigator b where
-      appName :: forall eff. b -> Eff (dom :: DOM | eff) String
-      appVersion :: forall eff. b -> Eff (dom :: DOM | eff) String
-      appCodeName :: forall eff. b -> Eff (dom :: DOM | eff) String
-      language :: forall eff. b -> Eff (dom :: DOM | eff) String
-      platform :: forall eff. b -> Eff (dom :: DOM | eff) String
-      product :: forall eff. b -> Eff (dom :: DOM | eff) String
-      userAgent :: forall eff. b -> Eff (dom :: DOM | eff) String
+``` purescript
+class Navigator b where
+  appName :: forall eff. b -> Eff (dom :: DOM | eff) String
+  appVersion :: forall eff. b -> Eff (dom :: DOM | eff) String
+  appCodeName :: forall eff. b -> Eff (dom :: DOM | eff) String
+  language :: forall eff. b -> Eff (dom :: DOM | eff) String
+  platform :: forall eff. b -> Eff (dom :: DOM | eff) String
+  product :: forall eff. b -> Eff (dom :: DOM | eff) String
+  userAgent :: forall eff. b -> Eff (dom :: DOM | eff) String
+```
 
 
-### Type Class Instances
+#### `domNavigator`
 
-    instance domNavigator :: Navigator DOMNavigator
+``` purescript
+instance domNavigator :: Navigator DOMNavigator
+```
+
 
 
 ## Module Data.DOM.Simple.NodeList
 
-### Type Classes
+#### `NodeListInst`
 
-    class NodeListInst b where
-      length :: forall eff. b -> Eff (dom :: DOM | eff) Number
-      item :: forall eff. Number -> b -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
-
-
-### Type Class Instances
-
-    instance nodeList :: NodeListInst NodeList
+``` purescript
+class NodeListInst b where
+  length :: forall eff. b -> Eff (dom :: DOM | eff) Number
+  item :: forall eff. Number -> b -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+```
 
 
-### Values
+#### `nodeList`
 
-    nodeListToArray :: forall eff. NodeList -> Eff (dom :: DOM | eff) [HTMLElement]
+``` purescript
+instance nodeList :: NodeListInst NodeList
+```
 
-    nodeListToArray' :: forall eff. NodeList -> Eff (dom :: DOM | eff) [HTMLElement]
+
+#### `nodeListToArray`
+
+``` purescript
+nodeListToArray :: forall eff. NodeList -> Eff (dom :: DOM | eff) [HTMLElement]
+```
+
+
+#### `nodeListToArray'`
+
+``` purescript
+nodeListToArray' :: forall eff. NodeList -> Eff (dom :: DOM | eff) [HTMLElement]
+```
+
 
 
 ## Module Data.DOM.Simple.Sugar
 
-### Type Classes
+#### `DOMArrows`
 
-    class DOMArrows b where
-      (#<-) :: forall eff. b -> Tuple String String -> Eff (dom :: DOM | eff) Unit
-      (<-#) :: forall eff. b -> String -> Eff (dom :: DOM | eff) String
-      (<-?) :: forall eff. b -> String -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
-      (%<-) :: forall eff. b -> String -> Eff (dom :: DOM | eff) Unit
-      (@<-) :: forall eff. b -> String -> Eff (dom :: DOM | eff) Unit
+``` purescript
+class DOMArrows b where
+  (#<-) :: forall eff. b -> Tuple String String -> Eff (dom :: DOM | eff) Unit
+  (<-#) :: forall eff. b -> String -> Eff (dom :: DOM | eff) String
+  (<-?) :: forall eff. b -> String -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+  (%<-) :: forall eff. b -> String -> Eff (dom :: DOM | eff) Unit
+  (@<-) :: forall eff. b -> String -> Eff (dom :: DOM | eff) Unit
+```
 
 
-### Type Class Instances
+#### `arrowsHTMLElement`
 
-    instance arrowsEffHTMLElement :: (Element a) => DOMArrows (Eff eff a)
+``` purescript
+instance arrowsHTMLElement :: (Element a) => DOMArrows a
+```
 
-    instance arrowsHTMLElement :: (Element a) => DOMArrows a
+#### `arrowsEffHTMLElement`
 
-    instance arrowsMaybeHTMLElement :: (Element a) => DOMArrows (Maybe a)
+``` purescript
+instance arrowsEffHTMLElement :: (Element a) => DOMArrows (Eff eff a)
+```
+
+#### `arrowsMaybeHTMLElement`
+
+``` purescript
+instance arrowsMaybeHTMLElement :: (Element a) => DOMArrows (Maybe a)
+```
 
 
 ## Module Data.DOM.Simple.Types
 
-### Types
+#### `HTMLElement`
 
-    data DOMEvent :: *
+``` purescript
+data HTMLElement :: *
+```
 
-    data DOMLocation :: *
 
-    data DOMNavigator :: *
+#### `HTMLDocument`
 
-    data HTMLDocument :: *
+``` purescript
+data HTMLDocument :: *
+```
 
-    data HTMLElement :: *
 
-    data HTMLWindow :: *
+#### `HTMLWindow`
 
-    data JavascriptContext :: *
+``` purescript
+data HTMLWindow :: *
+```
 
-    data Timeout :: *
 
-    data XMLHttpRequest :: *
+#### `XMLHttpRequest`
+
+``` purescript
+data XMLHttpRequest :: *
+```
+
+
+#### `DOMNavigator`
+
+``` purescript
+data DOMNavigator :: *
+```
+
+
+#### `DOMEvent`
+
+``` purescript
+data DOMEvent :: *
+```
+
+
+#### `DOMLocation`
+
+``` purescript
+data DOMLocation :: *
+```
+
+
+#### `JavascriptContext`
+
+``` purescript
+data JavascriptContext :: *
+```
+
+
+#### `Timeout`
+
+``` purescript
+data Timeout :: *
+```
+
 
 
 ## Module Data.DOM.Simple.Unsafe.Ajax
 
-### Values
+#### `unsafeReadyState`
 
-    unsafeGetResponseHeader :: forall eff a. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) String)
+``` purescript
+unsafeReadyState :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
+```
 
-    unsafeOnReadyStateChange :: forall eff e. Fn2 XMLHttpRequest (Eff e Unit) (Eff (dom :: DOM | eff) Unit)
 
-    unsafeOpen :: forall eff. Fn3 XMLHttpRequest String String (Eff (dom :: DOM | eff) Unit)
+#### `unsafeOnReadyStateChange`
 
-    unsafeReadyState :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) Number
+``` purescript
+unsafeOnReadyStateChange :: forall eff e. Fn2 XMLHttpRequest (Eff e Unit) (Eff (dom :: DOM | eff) Unit)
+```
 
-    unsafeResponse :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) a
 
-    unsafeResponseType :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+#### `unsafeOpen`
 
-    unsafeSend :: forall eff. Fn1 XMLHttpRequest (Eff (dom :: DOM | eff) Unit)
+``` purescript
+unsafeOpen :: forall eff. Fn3 XMLHttpRequest String String (Eff (dom :: DOM | eff) Unit)
+```
 
-    unsafeSendWithPayload :: forall eff a. Fn2 XMLHttpRequest a (Eff (dom :: DOM | eff) Unit)
 
-    unsafeSetResponseType :: forall eff. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) Unit)
+#### `unsafeSend`
+
+``` purescript
+unsafeSend :: forall eff. Fn1 XMLHttpRequest (Eff (dom :: DOM | eff) Unit)
+```
+
+
+#### `unsafeSendWithPayload`
+
+``` purescript
+unsafeSendWithPayload :: forall eff a. Fn2 XMLHttpRequest a (Eff (dom :: DOM | eff) Unit)
+```
+
+
+#### `unsafeSetResponseType`
+
+``` purescript
+unsafeSetResponseType :: forall eff. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) Unit)
+```
+
+
+#### `unsafeResponseType`
+
+``` purescript
+unsafeResponseType :: forall eff. XMLHttpRequest -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeResponse`
+
+``` purescript
+unsafeResponse :: forall eff a. XMLHttpRequest -> Eff (dom :: DOM | eff) a
+```
+
+
+#### `unsafeGetResponseHeader`
+
+``` purescript
+unsafeGetResponseHeader :: forall eff a. Fn2 XMLHttpRequest String (Eff (dom :: DOM | eff) String)
+```
+
 
 
 ## Module Data.DOM.Simple.Unsafe.Document
 
-### Values
+#### `unsafeTitle`
 
-    unsafeBody :: forall eff a. a -> Eff (dom :: DOM | eff) HTMLElement
+``` purescript
+unsafeTitle :: forall eff a. a -> Eff (dom :: DOM | eff) String
+```
 
-    unsafeSetBody :: forall eff a. HTMLElement -> a -> Eff (dom :: DOM | eff) Unit
 
-    unsafeSetTitle :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+#### `unsafeSetTitle`
 
-    unsafeTitle :: forall eff a. a -> Eff (dom :: DOM | eff) String
+``` purescript
+unsafeSetTitle :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeBody`
+
+``` purescript
+unsafeBody :: forall eff a. a -> Eff (dom :: DOM | eff) HTMLElement
+```
+
+
+#### `unsafeSetBody`
+
+``` purescript
+unsafeSetBody :: forall eff a. HTMLElement -> a -> Eff (dom :: DOM | eff) Unit
+```
+
 
 
 ## Module Data.DOM.Simple.Unsafe.Element
 
-### Values
+#### `unsafeGetElementById`
 
-    unsafeBlur :: forall eff a. a -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeGetElementById :: forall eff a. String -> a -> Eff (dom :: DOM | eff) HTMLElement
+```
 
-    unsafeChildren :: forall eff a. a -> Eff (dom :: DOM | eff) [HTMLElement]
 
-    unsafeClassAdd :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+#### `unsafeGetElementsByClassName`
 
-    unsafeClassContains :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Boolean
+``` purescript
+unsafeGetElementsByClassName :: forall eff a. String -> a -> Eff (dom :: DOM | eff) [HTMLElement]
+```
 
-    unsafeClassRemove :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
 
-    unsafeClassToggle :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+#### `unsafeGetElementsByName`
 
-    unsafeClick :: forall eff a. a -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeGetElementsByName :: forall eff a. String -> a -> Eff (dom :: DOM | eff) [HTMLElement]
+```
 
-    unsafeContentWindow :: forall eff a. a -> Eff (dom :: DOM | eff) HTMLWindow
 
-    unsafeFocus :: forall eff a. a -> Eff (dom :: DOM | eff) Unit
+#### `unsafeQuerySelector`
 
-    unsafeGetAttribute :: forall eff a. String -> a -> Eff (dom :: DOM | eff) String
+``` purescript
+unsafeQuerySelector :: forall eff a. String -> a -> Eff (dom :: DOM | eff) HTMLElement
+```
 
-    unsafeGetElementById :: forall eff a. String -> a -> Eff (dom :: DOM | eff) HTMLElement
 
-    unsafeGetElementsByClassName :: forall eff a. String -> a -> Eff (dom :: DOM | eff) [HTMLElement]
+#### `unsafeQuerySelectorAll`
 
-    unsafeGetElementsByName :: forall eff a. String -> a -> Eff (dom :: DOM | eff) [HTMLElement]
+``` purescript
+unsafeQuerySelectorAll :: forall eff a. String -> a -> Eff (dom :: DOM | eff) NodeList
+```
 
-    unsafeHasAttribute :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Boolean
 
-    unsafeInnerHTML :: forall eff a. a -> Eff (dom :: DOM | eff) String
+#### `unsafeGetAttribute`
 
-    unsafeQuerySelector :: forall eff a. String -> a -> Eff (dom :: DOM | eff) HTMLElement
+``` purescript
+unsafeGetAttribute :: forall eff a. String -> a -> Eff (dom :: DOM | eff) String
+```
 
-    unsafeQuerySelectorAll :: forall eff a. String -> a -> Eff (dom :: DOM | eff) NodeList
 
-    unsafeRemoveAttribute :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+#### `unsafeSetAttribute`
 
-    unsafeSetAttribute :: forall eff a. String -> String -> a -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeSetAttribute :: forall eff a. String -> String -> a -> Eff (dom :: DOM | eff) Unit
+```
 
-    unsafeSetInnerHTML :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
 
-    unsafeSetTextContent :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+#### `unsafeHasAttribute`
 
-    unsafeSetValue :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeHasAttribute :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Boolean
+```
 
-    unsafeTextContent :: forall eff a. a -> Eff (dom :: DOM | eff) String
 
-    unsafeValue :: forall eff a. a -> Eff (dom :: DOM | eff) String
+#### `unsafeRemoveAttribute`
+
+``` purescript
+unsafeRemoveAttribute :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeGetStyleAttr`
+
+``` purescript
+unsafeGetStyleAttr :: forall eff a. String -> a -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeSetStyleAttr`
+
+``` purescript
+unsafeSetStyleAttr :: forall eff a. String -> String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeChildren`
+
+``` purescript
+unsafeChildren :: forall eff a. a -> Eff (dom :: DOM | eff) [HTMLElement]
+```
+
+
+#### `unsafeInnerHTML`
+
+``` purescript
+unsafeInnerHTML :: forall eff a. a -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeSetInnerHTML`
+
+``` purescript
+unsafeSetInnerHTML :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeTextContent`
+
+``` purescript
+unsafeTextContent :: forall eff a. a -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeSetTextContent`
+
+``` purescript
+unsafeSetTextContent :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeValue`
+
+``` purescript
+unsafeValue :: forall eff a. a -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeSetValue`
+
+``` purescript
+unsafeSetValue :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeContentWindow`
+
+``` purescript
+unsafeContentWindow :: forall eff a. a -> Eff (dom :: DOM | eff) HTMLWindow
+```
+
+
+#### `unsafeClassAdd`
+
+``` purescript
+unsafeClassAdd :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeClassRemove`
+
+``` purescript
+unsafeClassRemove :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeClassToggle`
+
+``` purescript
+unsafeClassToggle :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeClassContains`
+
+``` purescript
+unsafeClassContains :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Boolean
+```
+
+
+#### `unsafeClick`
+
+``` purescript
+unsafeClick :: forall eff a. a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeFocus`
+
+``` purescript
+unsafeFocus :: forall eff a. a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeBlur`
+
+``` purescript
+unsafeBlur :: forall eff a. a -> Eff (dom :: DOM | eff) Unit
+```
+
 
 
 ## Module Data.DOM.Simple.Unsafe.Events
 
-### Values
+#### `unsafeAddEventListener`
 
-    unsafeAddEventListener :: forall eff t e b. String -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeAddEventListener :: forall eff t e b. String -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | eff) Unit
+```
 
-    unsafeEventBooleanProp :: forall eff. String -> DOMEvent -> Eff (dom :: DOM | eff) Boolean
 
-    unsafeEventKey :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) String
+#### `unsafeRemoveEventListener`
 
-    unsafeEventKeyCode :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) Number
+``` purescript
+unsafeRemoveEventListener :: forall eff t e b. String -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | eff) Unit
+```
 
-    unsafeEventNumberProp :: forall eff. String -> DOMEvent -> Eff (dom :: DOM | eff) Number
 
-    unsafeEventStringProp :: forall eff. String -> DOMEvent -> Eff (dom :: DOM | eff) String
+#### `unsafeEventTarget`
 
-    unsafeEventTarget :: forall eff a. DOMEvent -> Eff (dom :: DOM | eff) a
+``` purescript
+unsafeEventTarget :: forall eff a. DOMEvent -> Eff (dom :: DOM | eff) a
+```
 
-    unsafeEventView :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) HTMLWindow
 
-    unsafePreventDefault :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) Unit
+#### `unsafeStopPropagation`
 
-    unsafeRemoveEventListener :: forall eff t e b. String -> (e -> Eff (dom :: DOM | t) Unit) -> b -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeStopPropagation :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) Unit
+```
 
-    unsafeStopPropagation :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) Unit
+
+#### `unsafePreventDefault`
+
+``` purescript
+unsafePreventDefault :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeEventKey`
+
+``` purescript
+unsafeEventKey :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) String
+```
+
+#### `unsafeEventKeyCode`
+
+``` purescript
+unsafeEventKeyCode :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) Number
+```
+
+
+#### `unsafeEventNumberProp`
+
+``` purescript
+unsafeEventNumberProp :: forall eff. String -> DOMEvent -> Eff (dom :: DOM | eff) Number
+```
+
+
+#### `unsafeEventStringProp`
+
+``` purescript
+unsafeEventStringProp :: forall eff. String -> DOMEvent -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeEventBooleanProp`
+
+``` purescript
+unsafeEventBooleanProp :: forall eff. String -> DOMEvent -> Eff (dom :: DOM | eff) Boolean
+```
+
+
+#### `unsafeEventView`
+
+``` purescript
+unsafeEventView :: forall eff. DOMEvent -> Eff (dom :: DOM | eff) HTMLWindow
+```
 
 
 ## Module Data.DOM.Simple.Unsafe.Navigator
 
-### Values
+#### `unsafeAppName`
 
-    unsafeAppCodeName :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+``` purescript
+unsafeAppName :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+```
 
-    unsafeAppName :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
 
-    unsafeAppVersion :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+#### `unsafeAppVersion`
 
-    unsafeLanguage :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+``` purescript
+unsafeAppVersion :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+```
 
-    unsafePlatform :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
 
-    unsafeProduct :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+#### `unsafeAppCodeName`
 
-    unsafeUserAgent :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+``` purescript
+unsafeAppCodeName :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeLanguage`
+
+``` purescript
+unsafeLanguage :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafePlatform`
+
+``` purescript
+unsafePlatform :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeProduct`
+
+``` purescript
+unsafeProduct :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeUserAgent`
+
+``` purescript
+unsafeUserAgent :: forall eff. DOMNavigator -> Eff (dom :: DOM | eff) String
+```
+
 
 
 ## Module Data.DOM.Simple.Unsafe.NodeList
 
-### Values
+#### `unsafeNodeListLength`
 
-    unsafeNodeListItem :: forall eff. Number -> NodeList -> Eff (dom :: DOM | eff) HTMLElement
+``` purescript
+unsafeNodeListLength :: forall eff. NodeList -> Eff (dom :: DOM | eff) Number
+```
 
-    unsafeNodeListLength :: forall eff. NodeList -> Eff (dom :: DOM | eff) Number
 
-    unsafeNodeListToArray :: forall eff. NodeList -> Eff (dom :: DOM | eff) [HTMLElement]
+#### `unsafeNodeListItem`
+
+``` purescript
+unsafeNodeListItem :: forall eff. Number -> NodeList -> Eff (dom :: DOM | eff) HTMLElement
+```
+
+
+#### `unsafeNodeListToArray`
+
+``` purescript
+unsafeNodeListToArray :: forall eff. NodeList -> Eff (dom :: DOM | eff) [HTMLElement]
+```
+
 
 
 ## Module Data.DOM.Simple.Unsafe.Sugar
 
-### Values
+#### `dirtyKindDomRecast`
 
-    dirtyKindDomRecast :: forall eff effn a. (Element a) => Eff eff a -> Eff (dom :: DOM | effn) a
+``` purescript
+dirtyKindDomRecast :: forall eff effn a. (Element a) => Eff eff a -> Eff (dom :: DOM | effn) a
+```
 
 
 ## Module Data.DOM.Simple.Unsafe.Utils
 
-### Values
+#### `ensure3`
 
-    ensure3 :: forall a. Maybe a -> (a -> Maybe a) -> a -> Maybe a
+``` purescript
+ensure3 :: forall a. Maybe a -> (a -> Maybe a) -> a -> Maybe a
+```
 
-    showImpl :: forall a. a -> String
+
+#### `showImpl`
+
+``` purescript
+showImpl :: forall a. a -> String
+```
+
 
 
 ## Module Data.DOM.Simple.Unsafe.Window
 
-### Values
+#### `unsafeDocument`
 
-    unsafeClearTimeout :: forall eff b. b -> Timeout -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeDocument :: forall eff a. a -> Eff (dom :: DOM | eff) HTMLDocument
+```
 
-    unsafeDocument :: forall eff a. a -> Eff (dom :: DOM | eff) HTMLDocument
 
-    unsafeGetLocation :: forall eff a. a -> Eff (dom :: DOM | eff) String
+#### `unsafeNavigator`
 
-    unsafeGetSearchLocation :: forall eff a. a -> Eff (dom :: DOM | eff) String
+``` purescript
+unsafeNavigator :: forall eff a. a -> Eff (dom :: DOM | eff) DOMNavigator
+```
 
-    unsafeInnerHeight :: forall eff b. b -> Eff (dom :: DOM | eff) Number
 
-    unsafeInnerWidth :: forall eff b. b -> Eff (dom :: DOM | eff) Number
+#### `unsafeLocation`
 
-    unsafeLocation :: forall eff a. a -> Eff (dom :: DOM | eff) DOMLocation
+``` purescript
+unsafeLocation :: forall eff a. a -> Eff (dom :: DOM | eff) DOMLocation
+```
 
-    unsafeNavigator :: forall eff a. a -> Eff (dom :: DOM | eff) DOMNavigator
 
-    unsafeSetInterval :: forall eff b. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
+#### `unsafeGetLocation`
 
-    unsafeSetLocation :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+``` purescript
+unsafeGetLocation :: forall eff a. a -> Eff (dom :: DOM | eff) String
+```
 
-    unsafeSetTimeout :: forall eff b. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
+#### `unsafeSetLocation`
+
+``` purescript
+unsafeSetLocation :: forall eff a. String -> a -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeGetSearchLocation`
+
+``` purescript
+unsafeGetSearchLocation :: forall eff a. a -> Eff (dom :: DOM | eff) String
+```
+
+
+#### `unsafeSetTimeout`
+
+``` purescript
+unsafeSetTimeout :: forall eff b. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
+```
+
+
+#### `unsafeSetInterval`
+
+``` purescript
+unsafeSetInterval :: forall eff b. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
+```
+
+
+#### `unsafeClearTimeout`
+
+``` purescript
+unsafeClearTimeout :: forall eff b. b -> Timeout -> Eff (dom :: DOM | eff) Unit
+```
+
+
+#### `unsafeInnerWidth`
+
+``` purescript
+unsafeInnerWidth :: forall eff b. b -> Eff (dom :: DOM | eff) Number
+```
+
+
+#### `unsafeInnerHeight`
+
+``` purescript
+unsafeInnerHeight :: forall eff b. b -> Eff (dom :: DOM | eff) Number
+```
+
 
 
 ## Module Data.DOM.Simple.Window
 
-### Type Classes
+#### `Location`
 
-    class Location b where
-      getLocation :: forall eff. b -> Eff (dom :: DOM | eff) String
-      setLocation :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
-      search :: forall eff. b -> Eff (dom :: DOM | eff) String
-
-    class Window b where
-      document :: forall eff. b -> Eff (dom :: DOM | eff) HTMLDocument
-      navigator :: forall eff. b -> Eff (dom :: DOM | eff) DOMNavigator
-      location :: forall eff. b -> Eff (dom :: DOM | eff) DOMLocation
-      setTimeout :: forall eff. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
-      setInterval :: forall eff. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
-      clearTimeout :: forall eff. b -> Timeout -> Eff (dom :: DOM | eff) Unit
-      innerWidth :: forall eff. b -> Eff (dom :: DOM | eff) Number
-      innerHeight :: forall eff. b -> Eff (dom :: DOM | eff) Number
+``` purescript
+class Location b where
+  getLocation :: forall eff. b -> Eff (dom :: DOM | eff) String
+  setLocation :: forall eff. String -> b -> Eff (dom :: DOM | eff) Unit
+  search :: forall eff. b -> Eff (dom :: DOM | eff) String
+```
 
 
-### Type Class Instances
+#### `Window`
 
-    instance domLocation :: Location DOMLocation
+``` purescript
+class Window b where
+  document :: forall eff. b -> Eff (dom :: DOM | eff) HTMLDocument
+  navigator :: forall eff. b -> Eff (dom :: DOM | eff) DOMNavigator
+  location :: forall eff. b -> Eff (dom :: DOM | eff) DOMLocation
+  setTimeout :: forall eff. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
+  setInterval :: forall eff. b -> Number -> Eff (dom :: DOM | eff) Unit -> Eff (dom :: DOM | eff) Timeout
+  clearTimeout :: forall eff. b -> Timeout -> Eff (dom :: DOM | eff) Unit
+  innerWidth :: forall eff. b -> Eff (dom :: DOM | eff) Number
+  innerHeight :: forall eff. b -> Eff (dom :: DOM | eff) Number
+```
 
-    instance htmlWindow :: Window HTMLWindow
+
+#### `htmlWindow`
+
+``` purescript
+instance htmlWindow :: Window HTMLWindow
+```
 
 
-### Values
+#### `domLocation`
 
-    getLocationValue :: String -> String -> Maybe String
+``` purescript
+instance domLocation :: Location DOMLocation
+```
 
-    globalWindow :: HTMLWindow
+
+#### `globalWindow`
+
+``` purescript
+globalWindow :: HTMLWindow
+```
+
+
+#### `getLocationValue`
+
+``` purescript
+getLocationValue :: String -> String -> Maybe String
+```

--- a/src/Data/DOM/Simple/Document.purs
+++ b/src/Data/DOM/Simple/Document.purs
@@ -25,6 +25,8 @@ instance htmlDocumentElement :: Element HTMLDocument where
   setAttribute            = unsafeSetAttribute
   hasAttribute            = unsafeHasAttribute
   removeAttribute         = unsafeRemoveAttribute
+  getStyleAttr            = unsafeGetStyleAttr
+  setStyleAttr            = unsafeSetStyleAttr
   children                = unsafeChildren
   innerHTML               = unsafeInnerHTML
   setInnerHTML            = unsafeSetInnerHTML

--- a/src/Data/DOM/Simple/Element.purs
+++ b/src/Data/DOM/Simple/Element.purs
@@ -22,6 +22,8 @@ class Element b where
   setAttribute           :: forall eff. String -> String -> b -> (Eff (dom :: DOM | eff) Unit)
   hasAttribute           :: forall eff. String -> b -> (Eff (dom :: DOM | eff) Boolean)
   removeAttribute        :: forall eff. String -> b -> (Eff (dom :: DOM | eff) Unit)
+  getStyleAttr           :: forall eff. String -> b -> (Eff (dom :: DOM | eff) String)
+  setStyleAttr           :: forall eff. String -> String -> b -> (Eff (dom :: DOM | eff) Unit)
   children               :: forall eff. b -> (Eff (dom :: DOM | eff) [HTMLElement])
   innerHTML              :: forall eff. b -> (Eff (dom :: DOM | eff) String)
   setInnerHTML           :: forall eff. String -> b -> (Eff (dom :: DOM | eff) Unit)
@@ -45,6 +47,8 @@ instance htmlElement :: Element HTMLElement where
   setAttribute            = unsafeSetAttribute
   hasAttribute            = unsafeHasAttribute
   removeAttribute         = unsafeRemoveAttribute
+  getStyleAttr            = unsafeGetStyleAttr
+  setStyleAttr            = unsafeSetStyleAttr
   children                = unsafeChildren
   innerHTML               = unsafeInnerHTML
   setInnerHTML            = unsafeSetInnerHTML
@@ -63,6 +67,9 @@ instance showHtmlElement :: Show HTMLElement where
 
 setAttributes :: forall eff a. (Element a) => [(T.Tuple String String)] -> a -> (Eff (dom :: DOM | eff) Unit)
 setAttributes xs el = for_ xs (\kv -> setAttribute (T.fst kv) (T.snd kv) el)
+
+setStyleAttrs :: forall eff a. (Element a) => [(T.Tuple String String)] -> a -> (Eff (dom :: DOM | eff) Unit)
+setStyleAttrs xs el = for_ xs (\kv -> setStyleAttr (T.fst kv) (T.snd kv) el)
 
 click :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
 click = unsafeClick

--- a/src/Data/DOM/Simple/Unsafe/Element.purs
+++ b/src/Data/DOM/Simple/Unsafe/Element.purs
@@ -99,6 +99,29 @@ foreign import unsafeRemoveAttribute
     };
   }""" :: forall eff a. String -> a -> (Eff (dom :: DOM | eff) Unit)
 
+foreign import unsafeGetStyleAttr
+  """
+  function unsafeGetStyleAttr(name) {
+    return function (src) {
+      return function () {
+        return src.style[name];
+      };
+    };
+  }""" :: forall eff a. String -> a -> (Eff (dom :: DOM | eff) String)
+
+foreign import unsafeSetStyleAttr
+  """
+  function unsafeSetStyleAttr(name) {
+    return function (value) {
+      return function (src) {
+        return function () {
+          src.style[name] = value;
+          return {};
+        };
+      };
+    };
+  }""" :: forall eff a. String -> String -> a -> (Eff (dom :: DOM | eff) Unit)
+
 foreign import unsafeChildren
   """
   function unsafeChildren(src) {

--- a/tests/Tests.purs
+++ b/tests/Tests.purs
@@ -124,6 +124,13 @@ main = do
   testDiv1HasAttribute' <- hasAttribute "data-test" testDiv1
   quickCheck' 1 $ testDiv1HasAttribute' == false
 
+  trace "Able to set a style attribute on an element"
+
+  setStyleAttr "color" "red" testDiv1
+  testDiv1StyleAttr <- getStyleAttr "color" testDiv1
+
+  quickCheck' 1 $ testDiv1StyleAttr == "red"
+
   navigator <- navigator globalWindow
   trace "Able to receive the appName from navigator"
   appName navigator >>= (\name -> quickCheck' 1 $ name == "Node.js jsDom")


### PR DESCRIPTION
Is this a good fit for `purescript-simple-dom`?

Unfortunately, `unsafeGetStyleAttr` and `unsafeSetStyleAttr` must misbehave somewhat to meet their goals, because the range of attributes that may be set include— beyond [the specification][1]— methods to get/set browser-specific CSS extensions. For that reason, I thought it best to match the respective `getAttribute` and `setAttribute` type signatures.

One difference: calling `getAttribute` on a nonexistent attribute name returns `null`, while calling `getStyleAttr` on a nonexistent style attribute returns `undefined`. I'm unsure if this is a problem.

  [1]: http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-ElementCSSInlineStyle