### PR TITLE
Return Arrays instead of HTMLCollection

### DIFF
--- a/src/Data/DOM/Simple/Unsafe/Element.purs
+++ b/src/Data/DOM/Simple/Unsafe/Element.purs
@@ -20,7 +20,7 @@ foreign import unsafeGetElementsByClassName
   function unsafeGetElementsByClassName(targ_id) {
     return function (src) {
       return function () {
-        return src.getElementsByClassName(targ_id);
+        return Array.prototype.slice.call(src.getElementsByClassName(targ_id));
       };
     };
   }""" :: forall eff a. String -> a -> (Eff (dom :: DOM | eff) [HTMLElement])
@@ -30,7 +30,7 @@ foreign import unsafeGetElementsByName
   function unsafeGetElementsByName(targ_id) {
     return function (src) {
       return function () {
-        return src.getElementsByName(targ_id);
+        return Array.prototype.slice.call(src.getElementsByName(targ_id));
       };
     };
   }""" :: forall eff a. String -> a -> (Eff (dom :: DOM | eff) [HTMLElement])
@@ -103,7 +103,7 @@ foreign import unsafeChildren
   """
   function unsafeChildren(src) {
     return function () {
-      return src.children;
+      return Array.prototype.slice.call(src.children);
     };
   }""" :: forall eff a. a -> (Eff (dom :: DOM | eff) [HTMLElement])
 


### PR DESCRIPTION
This fixes possible runtime errors because purescript expects real arrays, according to the type signature. This fixes #25 (see detailed explanation there)