### PR TITLE
functions for element offset properties

### DIFF
--- a/src/Data/DOM/Simple/Document.purs
+++ b/src/Data/DOM/Simple/Document.purs
@@ -40,6 +40,11 @@ instance htmlDocumentElement :: Element HTMLDocument where
   classAdd                = unsafeClassAdd
   classToggle             = unsafeClassToggle
   classContains           = unsafeClassContains
+  offsetParent el         = (unsafeOffsetParent el) >>= (ensure >>> return)
+  offsetHeight            = unsafeOffsetHeight
+  offsetWidth             = unsafeOffsetWidth
+  offsetTop               = unsafeOffsetTop
+  offsetLeft              = unsafeOffsetLeft
 
 instance htmlDocument :: Document HTMLDocument where
   title                   = unsafeTitle

--- a/src/Data/DOM/Simple/Element.purs
+++ b/src/Data/DOM/Simple/Element.purs
@@ -37,6 +37,11 @@ class Element b where
   classAdd               :: forall eff. String -> b -> (Eff (dom :: DOM | eff) Unit)
   classToggle            :: forall eff. String -> b -> (Eff (dom :: DOM | eff) Unit)
   classContains          :: forall eff. String -> b -> (Eff (dom :: DOM | eff) Boolean)
+  offsetParent           :: forall eff. b -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+  offsetHeight           :: forall eff. b -> Eff (dom :: DOM | eff) Number
+  offsetWidth            :: forall eff. b -> Eff (dom :: DOM | eff) Number
+  offsetTop              :: forall eff. b -> Eff (dom :: DOM | eff) Number
+  offsetLeft             :: forall eff. b -> Eff (dom :: DOM | eff) Number
 
 instance htmlElement :: Element HTMLElement where
   getElementById id el    = (unsafeGetElementById id el) >>= (ensure >>> return)
@@ -63,6 +68,11 @@ instance htmlElement :: Element HTMLElement where
   classAdd                = unsafeClassAdd
   classToggle             = unsafeClassToggle
   classContains           = unsafeClassContains
+  offsetParent            = unsafeOffsetParent >>= (ensure >>> return)
+  offsetHeight            = unsafeOffsetHeight
+  offsetWidth             = unsafeOffsetWidth
+  offsetTop               = unsafeOffsetTop
+  offsetLeft              = unsafeOffsetLeft
 
 instance showHtmlElement :: Show HTMLElement where
   show = showImpl

--- a/src/Data/DOM/Simple/Element.purs
+++ b/src/Data/DOM/Simple/Element.purs
@@ -68,7 +68,7 @@ instance htmlElement :: Element HTMLElement where
   classAdd                = unsafeClassAdd
   classToggle             = unsafeClassToggle
   classContains           = unsafeClassContains
-  offsetParent            = unsafeOffsetParent >>= (ensure >>> return)
+  offsetParent el         = (unsafeOffsetParent el) >>= (ensure >>> return)
   offsetHeight            = unsafeOffsetHeight
   offsetWidth             = unsafeOffsetWidth
   offsetTop               = unsafeOffsetTop

--- a/src/Data/DOM/Simple/Unsafe/Element.purs
+++ b/src/Data/DOM/Simple/Unsafe/Element.purs
@@ -249,6 +249,46 @@ foreign import unsafeClassContains
     };
   }""" :: forall eff a. String -> a -> (Eff (dom :: DOM | eff) Boolean)
 
+foreign import unsafeOffsetParent
+  """
+  function unsafeOffsetParent(src) {
+    return function () {
+      return src.offsetParent;
+    };
+  }""" :: forall eff a. a -> Eff (dom :: DOM | eff) HTMLElement
+
+foreign import unsafeOffsetHeight
+  """
+  function unsafeOffsetHeight(src) {
+    return function () {
+      return src.offsetHeight;
+    };
+  }""" :: forall eff a. a -> Eff (dom :: DOM | eff) Number
+
+foreign import unsafeOffsetWidth
+  """
+  function unsafeOffsetWidth(src) {
+    return function () {
+      return src.offsetWidth;
+    };
+  }""" :: forall eff a. a -> Eff (dom :: DOM | eff) Number
+
+foreign import unsafeOffsetTop
+  """
+  function unsafeOffsetTop(src) {
+    return function () {
+      return src.offsetTop;
+    };
+  }""" :: forall eff a. a -> Eff (dom :: DOM | eff) Number
+
+foreign import unsafeOffsetLeft
+  """
+  function unsafeOffsetLeft(src) {
+    return function () {
+      return src.offsetLeft;
+    };
+  }""" :: forall eff a. a -> Eff (dom :: DOM | eff) Number
+
 foreign import unsafeClick
   """
   function unsafeClick(src) {

--- a/tests/Tests.purs
+++ b/tests/Tests.purs
@@ -79,7 +79,7 @@ main = do
   checkTagName "TEST3" testDiv3
   checkContents "testContent3" testDiv3
 
-  testDivs <- querySelectorAll ".nodeListDiv" doc
+  testDivs <- querySelectorAll "div" doc
 
   trace "Able to count items in a nodelist"
   NL.length testDivs >>= (\len -> quickCheck' 1 $ len == 2)
@@ -145,28 +145,25 @@ main = do
   -- Tests for offset* properties of an element. These behave strangely
   -- with Zombie.js, so these tests just ensure that a value is returned.
 
-  Just offsetDiv <- getElementById "testOffset" doc
-
   trace "Able to get the offsetParent of an element"
-
   -- HTMLElement.offsetParent is "undefined" in Zombie.js
-  noParent <- offsetParent offsetDiv
+  noParent <- offsetParent testDiv1
   quickCheck' 1 $ isNothing noParent
 
   trace "Able to get the offsetHeight of an element"
-  heightVal <- offsetHeight offsetDiv
+  heightVal <- offsetHeight testDiv1
   quickCheck' 1 $ heightVal == 0
 
   trace "Able to get the offsetWidth of an element"
-  widthVal <- offsetWidth offsetDiv
+  widthVal <- offsetWidth testDiv1
   quickCheck' 1 $ widthVal == 0
 
   trace "Able to get the offsetTop of an element"
-  topVal <- offsetTop offsetDiv
+  topVal <- offsetTop testDiv1
   quickCheck' 1 $ topVal == 0
 
   trace "Able to get the offsetLeft of an element"
-  leftVal <- offsetLeft offsetDiv
+  leftVal <- offsetLeft testDiv1
   quickCheck' 1 $ leftVal == 0
 
   -- Unavailable in Zombie

--- a/tests/Tests.purs
+++ b/tests/Tests.purs
@@ -79,7 +79,7 @@ main = do
   checkTagName "TEST3" testDiv3
   checkContents "testContent3" testDiv3
 
-  testDivs <- querySelectorAll "div" doc
+  testDivs <- querySelectorAll ".nodeListDiv" doc
 
   trace "Able to count items in a nodelist"
   NL.length testDivs >>= (\len -> quickCheck' 1 $ len == 2)
@@ -141,6 +141,33 @@ main = do
 
   trace "Able to append a child"
   appendChild docBody testDiv1
+
+  -- Tests for offset* properties of an element. These behave strangely
+  -- with Zombie.js, so these tests just ensure that a value is returned.
+
+  Just offsetDiv <- getElementById "testOffset" doc
+
+  trace "Able to get the offsetParent of an element"
+
+  -- HTMLElement.offsetParent is "undefined" in Zombie.js
+  noParent <- offsetParent offsetDiv
+  quickCheck' 1 $ isNothing noParent
+
+  trace "Able to get the offsetHeight of an element"
+  heightVal <- offsetHeight offsetDiv
+  quickCheck' 1 $ heightVal == 0
+
+  trace "Able to get the offsetWidth of an element"
+  widthVal <- offsetWidth offsetDiv
+  quickCheck' 1 $ widthVal == 0
+
+  trace "Able to get the offsetTop of an element"
+  topVal <- offsetTop offsetDiv
+  quickCheck' 1 $ topVal == 0
+
+  trace "Able to get the offsetLeft of an element"
+  leftVal <- offsetLeft offsetDiv
+  quickCheck' 1 $ leftVal == 0
 
   -- Unavailable in Zombie
   -- trace "Able to add a class"

--- a/tests/test.html
+++ b/tests/test.html
@@ -4,10 +4,13 @@
     <title>testTitle</title>
   </head>
   <body>
-    <div id="test1">testContent1</div>
-    <div class="test2">testContent2</div>
+    <div id="test1" class="nodeListDiv">testContent1</div>
+    <div class="test2 nodeListDiv">testContent2</div>
     <test3>testContent3</test3>
 
     <input id="input1" type="text">
+
+    <div id="testOffset"></div>
+
   </body>
 </html>

--- a/tests/test.html
+++ b/tests/test.html
@@ -4,13 +4,10 @@
     <title>testTitle</title>
   </head>
   <body>
-    <div id="test1" class="nodeListDiv">testContent1</div>
-    <div class="test2 nodeListDiv">testContent2</div>
+    <div id="test1">testContent1</div>
+    <div class="test2">testContent2</div>
     <test3>testContent3</test3>
 
     <input id="input1" type="text">
-
-    <div id="testOffset"></div>
-
   </body>
 </html>


### PR DESCRIPTION
Adds functions for the following HTMLElement properties:
- `offsetParent`
- `offsetHeight`
- `offsetWidth`
- `offsetLeft`
- `offsetTop`