### PR TITLE
Added ability to obtain "clientX" and "clientY" from mouse events

### DIFF
--- a/src/Data/DOM/Simple/Events.purs
+++ b/src/Data/DOM/Simple/Events.purs
@@ -59,11 +59,15 @@ class (Event e) <= MouseEvent e where
   mouseEventType :: forall eff. e -> (Eff (dom :: DOM | eff) MouseEventType)
   screenX :: forall eff. e -> (Eff (dom :: DOM | eff) Int)
   screenY :: forall eff. e -> (Eff (dom :: DOM | eff) Int)
+  clientX :: forall eff. e -> (Eff (dom :: DOM | eff) Int)
+  clientY :: forall eff. e -> (Eff (dom :: DOM | eff) Int)
 
 instance mouseEventDOMEvent :: MouseEvent DOMEvent where
   mouseEventType ev = read <$> unsafeEventStringProp "type" ev
   screenX = unsafeEventNumberProp "screenX"
   screenY = unsafeEventNumberProp "screenY"
+  clientX = unsafeEventNumberProp "clientX"
+  clientY = unsafeEventNumberProp "clientY"
 
 class MouseEventTarget b where
   addMouseEventListener :: forall e t ta. (MouseEvent e) =>


### PR DESCRIPTION
This change exposes the "clientX" and "clientY" properties of a DOM mouse event.

I need these for a game I'm working on (currently using `unsafeEventNumberProp` but this seems useful enough to include in this package).