### PR TITLE
Updated purescript-strings dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "purescript-maybe": "^0.3.0",
     "purescript-foldable-traversable": "^0.4.0",
     "purescript-tuples": "^0.4.0",
-    "purescript-strings": "^0.5.0",
+    "purescript-strings": "^0.7.0",
     "purescript-sets": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This commit updates the `purescript-strings` dependency to [0.7.x][1] to include a fix for an orphan `Bounded Char` instance. Using that updated dependency is one step towards compatibility with the newly introduced check for [orphan instances][2] in Purescript 0.7.3.

[1]: https://github.com/purescript/purescript-strings/releases/tag/v0.7.0
[2]: https://github.com/purescript/purescript/wiki/Error-Code-OrphanInstance