### PR TITLE
Enable access to window pageXOffset/pageYOffset properties

### DIFF
--- a/src/Data/DOM/Simple/Unsafe/Window.js
+++ b/src/Data/DOM/Simple/Unsafe/Window.js
@@ -80,3 +80,15 @@ exports.unsafeInnerHeight = function (win) {
     return win.innerHeight;
   };
 };
+
+exports.unsafePageXOffset = function (win) {
+  return function () {
+    return win.pageXOffset;
+  };
+};
+
+exports.unsafePageYOffset = function (win) {
+  return function () {
+    return win.pageYOffset;
+  };
+};

--- a/src/Data/DOM/Simple/Unsafe/Window.purs
+++ b/src/Data/DOM/Simple/Unsafe/Window.purs
@@ -30,3 +30,7 @@ foreign import unsafeClearTimeout :: forall eff b. b -> Timeout -> (Eff (dom :: 
 foreign import unsafeInnerWidth :: forall eff b. b -> (Eff (dom :: DOM | eff) Number)
 
 foreign import unsafeInnerHeight :: forall eff b. b -> (Eff (dom :: DOM | eff) Number)
+
+foreign import unsafePageXOffset :: forall eff b. b -> (Eff (dom :: DOM | eff) Number)
+
+foreign import unsafePageYOffset :: forall eff b. b -> (Eff (dom :: DOM | eff) Number)

--- a/src/Data/DOM/Simple/Window.purs
+++ b/src/Data/DOM/Simple/Window.purs
@@ -27,6 +27,8 @@ class Window b where
   clearTimeout :: forall eff. b -> Timeout -> (Eff (dom :: DOM | eff) Unit)
   innerWidth   :: forall eff. b -> (Eff (dom :: DOM | eff) Number)
   innerHeight  :: forall eff. b -> (Eff (dom :: DOM | eff) Number)
+  pageXOffset  :: forall eff. b -> (Eff (dom :: DOM | eff) Number)
+  pageYOffset  :: forall eff. b -> (Eff (dom :: DOM | eff) Number)
 
 instance htmlWindow :: Window HTMLWindow where
   document = unsafeDocument
@@ -37,6 +39,8 @@ instance htmlWindow :: Window HTMLWindow where
   clearTimeout = unsafeClearTimeout
   innerWidth   = unsafeInnerWidth
   innerHeight  = unsafeInnerHeight
+  pageXOffset  = unsafePageXOffset
+  pageYOffset  = unsafePageYOffset
 
 instance domLocation :: Location DOMLocation where
   getLocation = unsafeGetLocation


### PR DESCRIPTION
These are useful for example when computing relative offsets of a mouse event within an element while accounting for page scrolling.