### PR TITLE
Add progress events

### DIFF
--- a/src/Data/DOM/Simple/Events.purs
+++ b/src/Data/DOM/Simple/Events.purs
@@ -231,6 +231,55 @@ instance uiEventTargetHTMLWindow :: UIEventTarget HTMLWindow where
   addUIEventListener typ    = unsafeAddEventListener (show typ)
   removeUIEventListener typ = unsafeRemoveEventListener (show typ)
 
+data ProgressEventType = ProgressAbortEvent
+                       | ProgressErrorEvent
+                       | ProgressLoadEvent
+                       | ProgressLoadEndEvent
+                       | ProgressLoadStartEvent
+                       | ProgressProgressEvent
+                       | ProgressTimeoutEvent
+
+instance showProgressEventType :: Show ProgressEventType where
+    show ProgressAbortEvent     = "abort"
+    show ProgressErrorEvent     = "error"
+    show ProgressLoadEvent      = "load"
+    show ProgressLoadEndEvent   = "loadend"
+    show ProgressLoadStartEvent = "loadstart"
+    show ProgressProgressEvent  = "progress"
+    show ProgressTimeoutEvent   = "timeout"
+
+readProgressEventType "abort"     = ProgressAbortEvent
+readProgressEventType "error"     = ProgressErrorEvent
+readProgressEventType "load"      = ProgressLoadEvent
+readProgressEventType "loadend"   = ProgressLoadEndEvent
+readProgressEventType "loadstart" = ProgressLoadStartEvent
+readProgressEventType "progress"  = ProgressProgressEvent
+readProgressEventType "timeout"   = ProgressTimeoutEvent
+
+class (Event e) <= ProgressEvent e where
+    progressEventType :: forall eff. e -> (Eff (dom :: DOM | eff) ProgressEventType)
+    lengthComputable  :: forall eff. e -> (Eff (dom :: DOM | eff) Boolean)
+    loaded            :: forall eff. e -> (Eff (dom :: DOM | eff) Number)
+    total             :: forall eff. e -> (Eff (dom :: DOM | eff) Number)
+
+class ProgressEventTarget b where
+    addProgressEventListener :: forall e t ta. (ProgressEvent e) =>
+                                ProgressEventType
+                                    -> (e -> Eff (dom :: DOM | t) Unit)
+                                    -> b
+                                    -> (Eff (dom :: DOM | ta) Unit)
+
+    removeProgressEventListener :: forall e t ta. (ProgressEvent e) =>
+                                   ProgressEventType
+                                       -> (e -> Eff (dom :: DOM | t) Unit)
+                                       -> b
+                                       -> (Eff (dom :: DOM | ta) Unit)
+
+instance progressEventTargetXMLHttpRequest :: ProgressEventTarget XMLHttpRequest where
+    addProgressEventListener typ    = unsafeAddEventListener (show typ)
+    removeProgressEventListener typ = unsafeRemoveEventListener (show typ)
+
+
 {-
 instance eventTargetXMLHttpRequest :: EventTarget XMLHttpRequest where
   addEventListener = unsafeAddEventListener

--- a/src/Data/DOM/Simple/Events.purs
+++ b/src/Data/DOM/Simple/Events.purs
@@ -262,6 +262,12 @@ class (Event e) <= ProgressEvent e where
     loaded            :: forall eff. e -> (Eff (dom :: DOM | eff) Number)
     total             :: forall eff. e -> (Eff (dom :: DOM | eff) Number)
 
+instance progressEventDOMEvent :: ProgressEvent DOMEvent where
+    progressEventType ev = readProgressEventType <$> unsafeEventProp "type" ev
+    lengthComputable     = unsafeEventProp "lengthComputable"
+    loaded               = unsafeEventProp "loaded"
+    total                = unsafeEventProp "total"
+
 class ProgressEventTarget b where
     addProgressEventListener :: forall e t ta. (ProgressEvent e) =>
                                 ProgressEventType

--- a/src/Data/DOM/Simple/Unsafe/Events.js
+++ b/src/Data/DOM/Simple/Unsafe/Events.js
@@ -90,3 +90,11 @@ exports.unsafeEventView = function (event) {
     return event.view;
   };
 };
+
+exports.unsafeEventProp = function (prop) {
+  return function (event) {
+    return function () {
+      return event[prop];
+    };
+  };
+};

--- a/src/Data/DOM/Simple/Unsafe/Events.purs
+++ b/src/Data/DOM/Simple/Unsafe/Events.purs
@@ -28,3 +28,5 @@ foreign import unsafeEventStringProp :: forall eff. String -> DOMEvent -> (Eff (
 foreign import unsafeEventBooleanProp :: forall eff. String -> DOMEvent -> (Eff (dom :: DOM | eff) Boolean)
 
 foreign import unsafeEventView :: forall eff. DOMEvent -> (Eff (dom :: DOM | eff) HTMLWindow)
+
+foreign import unsafeEventProp :: forall v eff. String -> DOMEvent -> (Eff (dom :: DOM | eff) v)


### PR DESCRIPTION
Hi Ashley,

I was trying to update Chris Waterson's Asteroids (http://github.com/waterson/purescript-asteroids) to work with psc 0.8.5. (It was developed against a much older version of PureScript). The original used an old fork of your purescript-simple-dom library that had added progress events.

This pull request just adds in the progress events from his old fork.